### PR TITLE
Update events processing

### DIFF
--- a/android/src/main/java/com/mews/app/bloc/android/BlocViewModel.kt
+++ b/android/src/main/java/com/mews/app/bloc/android/BlocViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mews.app.bloc.BaseBloc
 import com.mews.app.bloc.Bloc
-import com.mews.app.bloc.Sink
 import com.mews.app.bloc.Transition
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -13,21 +12,18 @@ import kotlinx.coroutines.flow.FlowCollector
 abstract class BlocViewModel<EVENT : Any, STATE : Any> : ViewModel(), Bloc<EVENT, STATE> {
     abstract val initialState: STATE
 
-    override fun addAsync(event: EVENT) = bloc.addAsync(event)
-
     @InternalCoroutinesApi
     override suspend fun collect(collector: FlowCollector<STATE>) = bloc.collect(collector)
 
-    override suspend fun add(value: EVENT) = bloc.add(value)
+    override fun add(value: EVENT) = bloc.add(value)
 
     override val state: STATE get() = bloc.state
 
     private val bloc = object : BaseBloc<EVENT, STATE>(viewModelScope) {
         override val initialState: STATE by lazy { this@BlocViewModel.initialState }
 
-        override suspend fun Sink<STATE>.mapEventToState(event: EVENT) {
-            this@BlocViewModel.apply { mapEventToState(event) }
-        }
+        override suspend fun mapEventToState(event: EVENT, emitState: suspend (STATE) -> Unit) =
+            this@BlocViewModel.mapEventToState(event, emitState)
 
         override suspend fun onTransition(transition: Transition<EVENT, STATE>) =
             this@BlocViewModel.onTransition(transition)

--- a/core/src/main/kotlin/com/mews/app/bloc/BaseBloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/BaseBloc.kt
@@ -40,17 +40,15 @@ abstract class BaseBloc<EVENT : Any, STATE : Any>(private val scope: CoroutineSc
         }
     }
 
-    override suspend fun add(value: EVENT) {
-        try {
-            doOnEvent(value)
-            eventChannel.send(value)
-        } catch (e: Throwable) {
-            doOnError(e)
+    override fun add(value: EVENT) {
+        scope.launch {
+            try {
+                doOnEvent(value)
+                eventChannel.send(value)
+            } catch (e: Throwable) {
+                doOnError(e)
+            }
         }
-    }
-
-    override fun addAsync(event: EVENT) {
-        scope.launch { add(event) }
     }
 
     private suspend fun doOnEvent(event: EVENT) {
@@ -70,5 +68,7 @@ abstract class BaseBloc<EVENT : Any, STATE : Any>(private val scope: CoroutineSc
 }
 
 private class StateSink<S>(private val producerScope: ProducerScope<S>) : Sink<S> {
-    override suspend fun add(value: S) = producerScope.send(value)
+    override fun add(value: S) {
+        producerScope.launch { producerScope.send(value) }
+    }
 }

--- a/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
@@ -14,9 +14,9 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     override fun add(value: EVENT)
 
     /**
-     * Takes an incoming [event] and emits new [STATE].
+     * Processes an incoming [event] and optionally emits a new [STATE] with [emitState].
      */
-    suspend fun Sink<STATE>.mapEventToState(event: EVENT)
+    suspend fun mapEventToState(event: EVENT, emitState: suspend (STATE) -> Unit)
 
     /**
      * Called whenever [transition] occurs before state is updated.

--- a/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
@@ -11,12 +11,7 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     /**
      * Call this function to emit a new [EVENT] that should be processed by bloc.
      */
-    override suspend fun add(value: EVENT)
-
-    /**
-     * Call this function to emit a new [EVENT] asynchronously within bloc scope.
-     */
-    fun addAsync(event: EVENT)
+    override fun add(value: EVENT)
 
     /**
      * Takes an incoming [event] and emits new [STATE].

--- a/core/src/main/kotlin/com/mews/app/bloc/Sink.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Sink.kt
@@ -1,5 +1,5 @@
 package com.mews.app.bloc
 
 interface Sink<T> {
-    suspend fun add(value: T)
+    fun add(value: T)
 }

--- a/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
+++ b/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
@@ -130,4 +130,36 @@ class BlocTest {
         )
         Assert.assertEquals(expectedTransitions, delegate.transitions)
     }
+
+    @Test
+    fun `can emit event during event processing`() {
+        runBlocking {
+            val bloc = object : BaseBloc<Int, String>(scope) {
+                override val initialState: String = "0"
+
+                override suspend fun Sink<String>.mapEventToState(event: Int) {
+                    if (event == 2) add(10)
+                    add(event.toString())
+                }
+
+                override suspend fun onEvent(event: Int) {
+                    println("onEvent $event")
+                }
+
+                override suspend fun onError(error: Throwable) {
+                    println(error)
+                }
+            }
+            bloc.add(1)
+            bloc.add(2)
+            bloc.add(3)
+        }
+
+        val expectedTransitions = listOf(
+            Transition("0", 1, "1"),
+            Transition("1", 3, "3"),
+            Transition("3", 2, "2")
+        )
+        Assert.assertEquals(expectedTransitions, delegate.transitions)
+    }
 }

--- a/example/src/main/java/com/mews/app/bloc/example/MainActivity.kt
+++ b/example/src/main/java/com/mews/app/bloc/example/MainActivity.kt
@@ -14,8 +14,8 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
 
-        plus.setOnClickListener { vm.addAsync(MainEvent.Incremented) }
-        minus.setOnClickListener { vm.addAsync(MainEvent.Decremented) }
+        plus.setOnClickListener { vm.add(MainEvent.Incremented) }
+        minus.setOnClickListener { vm.add(MainEvent.Decremented) }
 
         connect(vm) { text.text = it.value.toString() }
     }

--- a/example/src/main/java/com/mews/app/bloc/example/MainViewModel.kt
+++ b/example/src/main/java/com/mews/app/bloc/example/MainViewModel.kt
@@ -1,6 +1,5 @@
 package com.mews.app.bloc.example
 
-import com.mews.app.bloc.Sink
 import com.mews.app.bloc.android.BlocViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.transform
@@ -8,9 +7,9 @@ import kotlinx.coroutines.flow.transform
 class MainViewModel : BlocViewModel<MainEvent, MainState>() {
     override val initialState: MainState = MainState()
 
-    override suspend fun Sink<MainState>.mapEventToState(event: MainEvent) = when (event) {
-        MainEvent.Incremented -> add(state.copy(value = state.value + 1))
-        MainEvent.Decremented -> add(state.copy(value = state.value - 1))
+    override suspend fun mapEventToState(event: MainEvent, emitState: suspend (MainState) -> Unit) = when (event) {
+        MainEvent.Incremented -> emitState(state.copy(value = state.value + 1))
+        MainEvent.Decremented -> emitState(state.copy(value = state.value - 1))
     }
 
     override fun transformEvents(events: Flow<MainEvent>): Flow<MainEvent> = events.transform {


### PR DESCRIPTION
Updated the way events are processed. Simplified `Bloc` interface: `mapEventToState` now takes `emitState` as a parameter instead of `Sink<State>` receiver. Fixes the situation when a new event is emitted during `mapEventToState`.