### PR TITLE
:zap: Update mapEventToState signature

### DIFF
--- a/android/src/main/java/com/mews/app/bloc/android/BlocViewModel.kt
+++ b/android/src/main/java/com/mews/app/bloc/android/BlocViewModel.kt
@@ -22,8 +22,8 @@ abstract class BlocViewModel<EVENT : Any, STATE : Any> : ViewModel(), Bloc<EVENT
     private val bloc = object : BaseBloc<EVENT, STATE>(viewModelScope) {
         override val initialState: STATE by lazy { this@BlocViewModel.initialState }
 
-        override suspend fun mapEventToState(event: EVENT, emitState: suspend (STATE) -> Unit) =
-            this@BlocViewModel.mapEventToState(event, emitState)
+        override suspend fun mapEventToState(event: EVENT): Flow<STATE> =
+            this@BlocViewModel.mapEventToState(event)
 
         override suspend fun onTransition(transition: Transition<EVENT, STATE>) =
             this@BlocViewModel.onTransition(transition)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
 
     testImplementation("junit", "junit", "4.12")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.7")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
     testImplementation(project(":testing"))
 }
 

--- a/core/src/main/kotlin/com/mews/app/bloc/BaseBloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/BaseBloc.kt
@@ -21,7 +21,7 @@ abstract class BaseBloc<EVENT : Any, STATE : Any>(private val scope: CoroutineSc
             channel.consumeAsFlow()
                 .let(::transformEvents)
                 .flatMapConcat { event ->
-                    channelFlow<STATE> { mapEventToState(event, ::send) }
+                    channelFlow { mapEventToState(event).onEach { send(it) }.collect() }
                         .map { Transition(stateFlow.value, event, it) }
                         .catch { doOnError(it) }
                         .let(::transformTransitions)

--- a/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
@@ -16,7 +16,7 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     /**
      * Processes an incoming [event] and optionally emits a new [STATE] with [emitState].
      */
-    suspend fun mapEventToState(event: EVENT, emitState: suspend (STATE) -> Unit)
+    suspend fun mapEventToState(event: EVENT): Flow<STATE>
 
     /**
      * Called whenever [transition] occurs before state is updated.

--- a/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
@@ -42,5 +42,5 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     /**
      * Transforms [transitions] before [onTransition] is called.
      */
-    fun transformTransitions(transitions: Flow<Transition<EVENT, STATE>>) = transitions
+    fun transformTransitions(transitions: Flow<Transition<EVENT, STATE>>): Flow<Transition<EVENT, STATE>> = transitions
 }

--- a/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
@@ -14,7 +14,7 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     override fun add(value: EVENT)
 
     /**
-     * Processes an incoming [event] and maps into a new [STATE].
+     * Processes an incoming [event] and maps it into a new [STATE].
      */
     suspend fun mapEventToState(event: EVENT): Flow<STATE>
 

--- a/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
+++ b/core/src/main/kotlin/com/mews/app/bloc/Bloc.kt
@@ -14,7 +14,7 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     override fun add(value: EVENT)
 
     /**
-     * Processes an incoming [event] and optionally emits a new [STATE] with [emitState].
+     * Processes an incoming [event] and maps into a new [STATE].
      */
     suspend fun mapEventToState(event: EVENT): Flow<STATE>
 
@@ -29,7 +29,7 @@ interface Bloc<EVENT : Any, STATE : Any> : Flow<STATE>, Sink<EVENT> {
     suspend fun onError(error: Throwable) {}
 
     /**
-     * Called whenever an [event] is [add]ted.
+     * Called whenever an [event] is [add]ed.
      */
     suspend fun onEvent(event: EVENT) {}
 

--- a/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
+++ b/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
@@ -104,12 +104,10 @@ class BlocTest {
 
                 override suspend fun mapEventToState(event: Int): Flow<String> = flowOf(event.toString())
 
-                // Could be simplified after https://github.com/Kotlin/kotlinx.coroutines/issues/2034
-                override fun transformEvents(events: Flow<Int>): Flow<Int> = channelFlow {
-                    val broadcast = events.broadcastIn(scope).asFlow()
-                    val eventTwo = broadcast.filter { it == 2 }.debounce(100)
-                    val otherEvents = broadcast.filter { it != 2 }
-                    merge(eventTwo, otherEvents).collect { send(it) }
+                override fun transformEvents(events: Flow<Int>): Flow<Int> {
+                    val eventTwo = events.filter { it == 2 }.debounce(100)
+                    val otherEvents = events.filter { it != 2 }
+                    return merge(eventTwo, otherEvents)
                 }
             }
             bloc.add(1)

--- a/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
+++ b/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
@@ -26,9 +26,7 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int): Flow<String> {
-                    return flow { emit(event.toString()) }
-                }
+                override suspend fun mapEventToState(event: Int): Flow<String> = flowOf(event.toString())
             }
             bloc.add(1)
             bloc.add(2)
@@ -53,9 +51,9 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int): Flow<String> {
+                override suspend fun mapEventToState(event: Int): Flow<String> = flow {
                     if (event == 2) throw IllegalArgumentException("Test error")
-                    return flow { emit(event.toString()) }
+                    emit(event.toString())
                 }
             }
             bloc.add(1)
@@ -80,11 +78,9 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int): Flow<String> =
-                    flow { emit(event.toString()) }
+                override suspend fun mapEventToState(event: Int): Flow<String> = flowOf(event.toString())
 
-                override fun transformEvents(events: Flow<Int>): Flow<Int> =
-                    events.filter { it != 2 }
+                override fun transformEvents(events: Flow<Int>): Flow<Int> = events.filter { it != 2 }
             }
             bloc.add(1)
             bloc.add(2)
@@ -106,8 +102,7 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int): Flow<String> =
-                    flow { emit(event.toString()) }
+                override suspend fun mapEventToState(event: Int): Flow<String> = flowOf(event.toString())
 
                 // Could be simplified after https://github.com/Kotlin/kotlinx.coroutines/issues/2034
                 override fun transformEvents(events: Flow<Int>): Flow<Int> = channelFlow {
@@ -139,13 +134,13 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int): Flow<String> =
+                override suspend fun mapEventToState(event: Int): Flow<String> = flow {
                     if (event == 2) {
                         add(10)
-                        flow { }
                     } else {
-                        flow { emit(event.toString()) }
+                        emit(event.toString())
                     }
+                }
             }
             bloc.add(1)
             bloc.add(2)

--- a/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
+++ b/core/src/test/kotlin/com/mews/app/bloc/BlocTest.kt
@@ -26,8 +26,8 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int, emitState: suspend (String) -> Unit) {
-                    emitState(event.toString())
+                override suspend fun mapEventToState(event: Int): Flow<String> {
+                    return flow { emit(event.toString()) }
                 }
             }
             bloc.add(1)
@@ -53,9 +53,9 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int, emitState: suspend (String) -> Unit) {
+                override suspend fun mapEventToState(event: Int): Flow<String> {
                     if (event == 2) throw IllegalArgumentException("Test error")
-                    emitState(event.toString())
+                    return flow { emit(event.toString()) }
                 }
             }
             bloc.add(1)
@@ -80,11 +80,11 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int, emitState: suspend (String) -> Unit) =
-                    emitState(event.toString())
+                override suspend fun mapEventToState(event: Int): Flow<String> =
+                    flow { emit(event.toString()) }
 
-                override fun transformEvents(flow: Flow<Int>): Flow<Int> =
-                    flow.filter { it != 2 }
+                override fun transformEvents(events: Flow<Int>): Flow<Int> =
+                    events.filter { it != 2 }
             }
             bloc.add(1)
             bloc.add(2)
@@ -106,8 +106,8 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int, emitState: suspend (String) -> Unit) =
-                    emitState(event.toString())
+                override suspend fun mapEventToState(event: Int): Flow<String> =
+                    flow { emit(event.toString()) }
 
                 // Could be simplified after https://github.com/Kotlin/kotlinx.coroutines/issues/2034
                 override fun transformEvents(events: Flow<Int>): Flow<Int> = channelFlow {
@@ -139,8 +139,13 @@ class BlocTest {
             val bloc = object : BaseBloc<Int, String>(scope) {
                 override val initialState: String = "0"
 
-                override suspend fun mapEventToState(event: Int, emitState: suspend (String) -> Unit) =
-                    if (event == 2) add(10) else emitState(event.toString())
+                override suspend fun mapEventToState(event: Int): Flow<String> =
+                    if (event == 2) {
+                        add(10)
+                        flow { }
+                    } else {
+                        flow { emit(event.toString()) }
+                    }
             }
             bloc.add(1)
             bloc.add(2)

--- a/example/src/main/java/com/mews/app/bloc/example/MainViewModel.kt
+++ b/example/src/main/java/com/mews/app/bloc/example/MainViewModel.kt
@@ -2,14 +2,15 @@ package com.mews.app.bloc.example
 
 import com.mews.app.bloc.android.BlocViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.transform
 
 class MainViewModel : BlocViewModel<MainEvent, MainState>() {
     override val initialState: MainState = MainState()
 
-    override suspend fun mapEventToState(event: MainEvent, emitState: suspend (MainState) -> Unit) = when (event) {
-        MainEvent.Incremented -> emitState(state.copy(value = state.value + 1))
-        MainEvent.Decremented -> emitState(state.copy(value = state.value - 1))
+    override suspend fun mapEventToState(event: MainEvent): Flow<MainState> = when (event) {
+        MainEvent.Incremented -> flowOf(state.copy(value = state.value + 1))
+        MainEvent.Decremented -> flowOf(state.copy(value = state.value - 1))
     }
 
     override fun transformEvents(events: Flow<MainEvent>): Flow<MainEvent> = events.transform {

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
 
     implementation(project(":core"))
 


### PR DESCRIPTION
1. `mapEventToState` now returns `Flow<STATE>` instead of using `emitState` parameter. It's a breaking change.
2. `BaseBloc` now uses `SharedFlow` instead of a channel for events processing. This by its own shouldn't introduce any changes in behavior.
3. `kotlinx-coroutines` updated to `1.4.2`.